### PR TITLE
k8s probe

### DIFF
--- a/probes/Kubernetes/.gitignore
+++ b/probes/Kubernetes/.gitignore
@@ -1,0 +1,2 @@
+env/
+kubernetes.ipynb

--- a/probes/Kubernetes/kubernetes.py
+++ b/probes/Kubernetes/kubernetes.py
@@ -1,0 +1,130 @@
+from glob import glob
+import sys
+import os
+from collections import namedtuple
+from dataclasses import dataclass
+from typing import List, Optional
+
+from graphviz import Digraph
+import yaml
+from dockerfile_parse import DockerfileParser as Dockerfile
+
+Port = namedtuple('Port', ['port', 'target_port'])
+Deployment = namedtuple('Deployment', ['name'])
+
+@dataclass
+class Port(object):
+    name: Optional[str]
+    port: int
+    target_port: int
+
+
+@dataclass
+class Service(object):
+    name: str
+    ports: List[Port]
+
+
+@dataclass
+class Env(object):
+    name: str
+    value: str
+
+
+@dataclass
+class Container(object):
+    name: str
+    image: str
+    ports: List[int]
+    envs: List[Env]
+
+
+@dataclass
+class Deployment(object):
+    name: str
+    containers: List[Container]
+
+
+@dataclass
+class Image(object):
+    image: str
+    context: str
+    dockerfile: Dockerfile
+
+
+deployments: List[Deployment] = []
+services: List[Service] = []
+images: List[Image] = []
+
+# Find a skaffold.yaml field
+
+with open(f"{sys.argv[1]}/skaffold.yaml", "r") as f:
+    skaffold = yaml.safe_load(f)
+    manifests = skaffold['deploy']['kubectl']['manifests']
+    for build in skaffold['build']['artifacts']:
+        images.append(Image(
+            image=build['image'],
+            context=build['context'],
+            dockerfile=Dockerfile(f"{sys.argv[1]}/{build['context']}"),
+        ))
+
+# Read k8s files
+for manifest in manifests:
+    for file in glob(os.path.join(sys.argv[1], manifest)):
+        with open(file, "r") as f:
+            for doc in yaml.safe_load_all(f):
+                if doc['kind'] == "Service":
+                    ports = []
+                    for port in doc['spec'].get('ports', []):
+                        ports.append(Port(name=port['name'], port=port['port'], target_port=port['targetPort']))
+                    services.append(Service(
+                        name=doc['metadata']['name'],
+                        ports=port,
+                    ))
+                elif doc['kind'] == "Deployment":
+                    containers = []
+                    for container in doc['spec']['template']['spec']['containers']:
+                        envs = []
+                        for env in container.get('env', []):
+                            envs.append(Env(name=env['name'], value=env['value']))
+
+                        containers.append(Container(
+                            name=container['name'],
+                            image=container['image'],
+                            ports=[v.values() for v in container.get('ports', [])],
+                            envs=envs,
+                        ))
+
+                    deployments.append(Deployment(
+                        name=doc['metadata']['name'],
+                        containers=containers
+                    ))
+
+
+def detect_service_addr(addr):
+    #TODO use URI() to parse
+    if ':' in addr:
+        return addr.split(':')
+    return None
+
+def find_service(name):
+    for service in services:
+        if service.name == name:
+            return service
+
+service_graph = Digraph()
+for service in services:
+    service_graph.node(service.name)
+for deployment in deployments:
+    for container in deployment.containers:
+        for env in container.envs:
+            tentative_service = detect_service_addr(env.value)
+            if tentative_service:
+                u = find_service(deployment.name)
+                v = find_service(tentative_service[0])
+                if u and v:
+                    service_graph.edge(u.name, v.name)
+
+service_graph.render('service.dot')
+
+print("Service graph generated in `service.dot`")

--- a/probes/Kubernetes/requirements.txt
+++ b/probes/Kubernetes/requirements.txt
@@ -1,0 +1,11 @@
+pudb==2019.2
+PyYAML==5.3.1
+dockerfile-parse==0.0.17
+jupyter==1.0.0
+wheel==0.34.2
+networkx==2.4
+matplotlib==3.2.1
+uri==2.0.1
+scipy==1.4.1
+graphviz==0.14
+pygraphviz==1.5


### PR DESCRIPTION
This adds a kubernetes (and skaffold) probe.

It will try to read the skaffold configuration, and from there it will read the kubernetes deployment manifests. It will try to map the services with the deployments found in the manfiest and link them together when an environment variable is exposed with the `<service name>:<port>` format.

